### PR TITLE
Infer scalafmt version from `.scalafmt.conf` instead of using arg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,5 +8,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Checking testdata (pass)
         uses: ./
+        working-directory: .github/testdata
         with:
-          args: "-c .github/testdata/.scalafmt.conf --exclude .github/testdata/Bad.scala --list"
+          args: "--exclude Bad.scala --list"

--- a/action.yml
+++ b/action.yml
@@ -9,25 +9,28 @@ inputs:
     description: "Args to pass to scalafmt"
     default: "--list"
     required: false
-  version:
-    description: "Version of scalafmt"
-    default: "3.7.15"
-    required: false
 
 runs:
   using: "composite"
   steps:
   - shell: bash
     run: |
+      version=$(perl -ne 'next unless /^\s*version\s*=\s*(\d+\.\d+\.\d+)/; print "$1"; last' .scalafmt.conf)
+      if [ -z "$version" ]; then
+        echo "Failed to extract scalafmt version from .scalafmt.conf"
+        exit 1
+      fi
+      echo "scalafmt_version=$version" >> "$GITHUB_ENV"
+  - shell: bash
+    run: |
       "$action_path/set-path.sh"
     env:
-      scalafmt_version: ${{ inputs.version }}
       action_path: ${{ github.action_path }}
   - uses: actions/cache/restore@v4
     id: cache
     with:
       path: ${{ env.SCALAFMT_PATH }}
-      key: scalafmt-${{ inputs.version }}
+      key: scalafmt-${{ env.scalafmt_version }}
   - shell: bash
     id: retrieve-scalafmt
     if: ${{ !steps.cache.outputs.cache-hit }}
@@ -45,4 +48,4 @@ runs:
     uses: actions/cache/save@v4
     with:
       path: ${{ env.SCALAFMT_PATH }}
-      key: scalafmt-${{ inputs.version }}
+      key: scalafmt-${{ env.scalafmt_version }}

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
     run: |
       version=$(perl -ne 'next unless /^\s*version\s*=\s*(\d+\.\d+\.\d+)/; print "$1"; last' .scalafmt.conf)
       if [ -z "$version" ]; then
-        echo "Failed to extract scalafmt version from .scalafmt.conf"
+        echo "Failed to extract scalafmt version from .scalafmt.conf" >> "$GITHUB_STEP_SUMMARY"
         exit 1
       fi
       echo "scalafmt_version=$version" >> "$GITHUB_ENV"

--- a/run-scalafmt.sh
+++ b/run-scalafmt.sh
@@ -7,7 +7,7 @@ scalafmt --non-interactive $args > "$output" 2> "$warnings"
 result=$?
 cat "$output"
 cat "$warnings" >&2
-[ $result -eq 0 ] && exit
+[ $result -eq 0 ] && echo "All files well-formatted ✨" >> "$GITHUB_STEP_SUMMARY" && exit
 
 report() {
     file="$1"

--- a/run-scalafmt.sh
+++ b/run-scalafmt.sh
@@ -3,13 +3,6 @@ output=$(mktemp)
 warnings=$(mktemp)
 errors=$(mktemp)
 
-enforce_scala_format_version() {
-  if [ -e .scalafmt.conf ]; then
-    perl -pi -e 'next unless s/^\s*(version)=.*/$1=$ENV{scalafmt_version}/' .scalafmt.conf
-  fi
-}
-
-enforce_scala_format_version
 scalafmt --non-interactive $args > "$output" 2> "$warnings"
 result=$?
 cat "$output"


### PR DESCRIPTION
The [version](https://scalameta.org/scalafmt/docs/configuration.html#version) field in Scalafmt is mandatory, so passing it as an action argument is unnecessary.
> Since v3.1.0, the version parameter is required to be specified explicitly.

The action will always read the version field from `.scalafmt.conf` instead.





