### PR TITLE
Add Inputs `working-directory`

### DIFF
--- a/.github/workflows/detect-new-secrets.yml
+++ b/.github/workflows/detect-new-secrets.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Configuration
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Secret Scanner
         uses: secret-scanner/action@bf855b904a8bca17a334986797650dacec7ed529

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -5,7 +5,7 @@ jobs:
   check-testdata:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Checking testdata
         uses: ./
         with:

--- a/.github/workflows/test-regenerate-good.yml
+++ b/.github/workflows/test-regenerate-good.yml
@@ -5,7 +5,7 @@ jobs:
   regenerate-good:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Checking testdata
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   check-good-testdata:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Checking testdata (pass)
         uses: ./
         working-directory: .github/testdata

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Checking testdata (pass)
         uses: ./
-        working-directory: .github/testdata
         with:
+          working-directory: .github/testdata
           args: "--exclude Bad.scala --list"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
   scalafmt-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Checking your code to see if u r naughty or nice
         uses: garnercorp/scalafmt-ci@v3
         with:

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,16 @@ inputs:
     description: "Args to pass to scalafmt"
     default: "--list"
     required: false
+  working-directory:
+    description: "Working directory"
+    default: "${{ github.workspace }}"
+    required: false
 
 runs:
   using: "composite"
   steps:
   - shell: bash
+    working-directory: ${{ inputs.working-directory }}
     run: |
       version=$(perl -ne 'next unless /^\s*version\s*=\s*(\d+\.\d+\.\d+)/; print "$1"; last' .scalafmt.conf)
       if [ -z "$version" ]; then
@@ -39,6 +44,7 @@ runs:
       chmod +x "$SCALAFMT_PATH/scalafmt"
       echo "retrieved=1" >> "$GITHUB_OUTPUT"
   - shell: bash
+    working-directory: ${{ inputs.working-directory }}
     run: |
       run-scalafmt.sh
     env:

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
       "$action_path/set-path.sh"
     env:
       action_path: ${{ github.action_path }}
-  - uses: actions/cache/restore@v4
+  - uses: actions/cache/restore@v5
     id: cache
     with:
       path: ${{ env.SCALAFMT_PATH }}
@@ -45,7 +45,7 @@ runs:
       args: ${{ inputs.args }}
   - name: Cache scalafmt
     if: ${{ always() && steps.retrieve-scalafmt.outputs.retrieved }}
-    uses: actions/cache/save@v4
+    uses: actions/cache/save@v5
     with:
       path: ${{ env.SCALAFMT_PATH }}
       key: scalafmt-${{ env.scalafmt_version }}


### PR DESCRIPTION
Often projects have an alternate working-directory (e.g. this repository's tests).
This input enables them to use this action.